### PR TITLE
Fix panic on kill on already exited pid

### DIFF
--- a/cmd/sig/sig.go
+++ b/cmd/sig/sig.go
@@ -40,7 +40,7 @@ func main() {
 				reap()
 			}
 			err := unix.Kill(*pid, sig.(syscall.Signal))
-			if err != nil {
+			if err != nil && err != unix.ESRCH {
 				panic(err)
 			}
 		}


### PR DESCRIPTION
If the main process exited between us getting the signal and calling
kill on the process, we'd get an error saying the process did not exist.