### PR TITLE
Fix panic on disappearing children

### DIFF
--- a/cmd/sig/sig.go
+++ b/cmd/sig/sig.go
@@ -62,9 +62,16 @@ func main() {
 func reap() {
 	var waitstatus unix.WaitStatus
 	var rusage unix.Rusage
+Loop:
 	for {
 		wpid, err := unix.Wait4(-1, &waitstatus, unix.WNOHANG, &rusage)
-		if err != nil {
+		switch err {
+		case unix.ECHILD:
+			break Loop
+		case unix.EINTR:
+			continue
+		case nil:
+		default:
 			panic(err)
 		}
 		if wpid <= 0 {


### PR DESCRIPTION
If any child processes disappears before we can wait for it we'd panic
with a "no child processes" error. Since it is the goal to reap any
remaining child processes, it should not be seen as an error.